### PR TITLE
ramips: remove factory image for TP-Link Archer C2 v1

### DIFF
--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -631,7 +631,6 @@ define Device/tplink_c2-v1
   TPLINK_FLASHLAYOUT := 8Mmtk
   TPLINK_HWID := 0xc7500001
   TPLINK_HWREV := 50
-  IMAGES += factory.bin
   DEVICE_TITLE := TP-Link Archer C2 v1
   DEVICE_PACKAGES := kmod-mt76x0e kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport kmod-switch-rtl8366-smi kmod-switch-rtl8367b
 endef


### PR DESCRIPTION
Initial commit 8375623a0640 ("ramips: add support for TP-Link Archer
C2") contains detailed installation instructions, which do not mention
a factory image. From what I can see, no support to install OpenWrt
through the vendor web interface has been added since. The factory
image is also conspicuously absent from the device page in the wiki.
Yet, it is available for download.

I bricked my Archer C2 loading the factory image through the web UI.
Serial showed this error during bootloop:

  Uncompressing Kernel Image ... LZMA ERROR 1 - must RESET board to recover

This patch disables the undocumented factory image so users won't get
tricked into thinking easy web UI flashing actually works.

Signed-off-by: Stijn Segers <foss@volatilesystems.org>
(backported from commit ad5e29d38a48ce6ffbcabaf5d83bc76a64dfbe56)